### PR TITLE
feat: Add backup and replication configuration for MySQL RDS instances

### DIFF
--- a/data-stores/mysql/main.tf
+++ b/data-stores/mysql/main.tf
@@ -1,10 +1,27 @@
+terraform {
+    required_providers {
+        aws = {
+            source = "hashicorp/aws"
+            version = "~> 4.0"
+        }
+    }
+}
+
 resource "aws_db_instance" "example" {
     identifier_prefix = "terraform-kdash-example"
-    engine = "mysql"
     allocated_storage = 10
     instance_class = var.instance_type
-    db_name = "example_database"
     skip_final_snapshot = true
-    username = var.db_username
-    password = var.db_password
+    
+    # バックアップを有効化
+    backup_retention_period = var.backup_retention_period
+    
+    # 設定されている時はこのデータベースはレプリカ
+    replicate_source_db = var.replication_source_db
+
+    # replicate_source_db が指定されていない場合のみこれらのパラメータを設定する
+    engine =  var.replication_source_db == null ? "mysql" : null
+    db_name = var.backup_retention_period == null ? var.db_name : null
+    username = var.backup_retention_period == null ? var.db_username : null
+    password = var.backup_retention_period == null ? var.db_password : null
 }

--- a/data-stores/mysql/outputs.tf
+++ b/data-stores/mysql/outputs.tf
@@ -7,3 +7,8 @@ output "port" {
     value = aws_db_instance.example.port
     description = "The port to access the database on"
 }
+
+output "arn" {
+    value = aws_db_instance.example.arn
+    description = "The ARN of the RDS instance"
+}

--- a/data-stores/mysql/variables.tf
+++ b/data-stores/mysql/variables.tf
@@ -2,15 +2,35 @@ variable "db_username" {
     description = "The username for the database"
     type = string
     sensitive = true
+    default = null
 }
 
 variable "db_password" {
     description = "The password for the database"
     type = string
     sensitive = true
+    default = null
+}
+
+variable "db_name" {
+    description = "The name of the database"
+    type = string
+    default = null
 }
 
 variable "instance_type" {
     description = "The type of RDS Instance"
     type = string
+}
+
+variable "backup_retention_period" {
+    description = "Days to retain backups. Must be > 0 to enable replication."
+    type = number
+    default = null
+}
+
+variable "replication_source_db" {
+    description = "If specified, replicate the RDS database at the given ARN."
+    type = string
+    default = null
 }


### PR DESCRIPTION
- バックアップとレプリケーションの設定のための変数を追加
- 必須のプロバイダー構成を追加
- 特定の条件に基づいてデータベースのパラメータを設定
- ARN出力を追加

Branch name: feature/mysql-backup-replication