### PR TITLE
feat: Add multi-account AWS configuration with identity outputs

### DIFF
--- a/multi-account/main.tf
+++ b/multi-account/main.tf
@@ -1,0 +1,17 @@
+terraform {
+    required_providers {
+        aws = {
+            source = "hashicorp/aws"
+            version = "~> 5.0"
+            configuration_aliases = [aws.parent, aws.child]
+        }
+    }
+}
+
+data "aws_caller_identity" "parent" {
+    provider = aws.parent
+}
+
+data "aws_caller_identity" "child" {
+    provider = aws.child
+}

--- a/multi-account/outputs.tf
+++ b/multi-account/outputs.tf
@@ -1,0 +1,9 @@
+output "parent_account_id" {
+    value = data.aws_caller_identity.parent.account_id
+    description = "The ID of the parent AWS account"
+}
+
+output "child_account_id" {
+    value = data.aws_caller_identity.child.account_id
+    description = "The ID of the child AWS accont"
+}


### PR DESCRIPTION
multi-accountディレクトリにmain.tfとoutputs.tfを追加し、親および子AWSアカウントの設定を行いました。main.tfでは、AWSプロバイダーのバージョン5.0を使用し、親と子のプロバイダーエイリアスを設定しました。outputs.tfでは、それぞれのAWSアカウントのIDを出力するようにしました。

ブランチ名: feat/multi-account-setup